### PR TITLE
Add grid/text popup windows

### DIFF
--- a/WpfApp3/DataGridViewerWindow.xaml
+++ b/WpfApp3/DataGridViewerWindow.xaml
@@ -1,0 +1,9 @@
+<Window x:Class="ScriptArcade.DataGridViewerWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Grid Viewer" Height="450" Width="800">
+    <DockPanel>
+        <Button Content="Close" DockPanel.Dock="Bottom" Margin="5" Width="80" Click="Close_Click"/>
+        <DataGrid x:Name="gridPopout" ItemsSource="{Binding GridData}" AutoGenerateColumns="True"/>
+    </DockPanel>
+</Window>

--- a/WpfApp3/DataGridViewerWindow.xaml.cs
+++ b/WpfApp3/DataGridViewerWindow.xaml.cs
@@ -1,0 +1,25 @@
+using System.Windows;
+
+namespace ScriptArcade
+{
+    public partial class DataGridViewerWindow : Window
+    {
+        public object GridData
+        {
+            get => gridPopout.ItemsSource;
+            set => gridPopout.ItemsSource = value;
+        }
+
+        public DataGridViewerWindow(object data)
+        {
+            InitializeComponent();
+            GridData = data;
+            DataContext = this;
+        }
+
+        private void Close_Click(object sender, RoutedEventArgs e)
+        {
+            Close();
+        }
+    }
+}

--- a/WpfApp3/LogViewer.xaml
+++ b/WpfApp3/LogViewer.xaml
@@ -5,13 +5,16 @@
         Title="Script Editor" Height="450" Width="800">
     <Grid>
         <avalonEdit:TextEditor x:Name="ViewerPopout"
+                               Text="{Binding LogText, UpdateSourceTrigger=PropertyChanged}"
                                FontFamily="Consolas"
                                FontSize="14"
                                ShowLineNumbers="True"
                                HorizontalScrollBarVisibility="Auto"
-                               VerticalScrollBarVisibility="Auto"
-                               />
-        <Button Content="Save and Close" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="10"
+                               VerticalScrollBarVisibility="Auto" />
+        <Button Content="Save and Close"
+                HorizontalAlignment="Right"
+                VerticalAlignment="Bottom"
+                Margin="10"
                 Click="SaveAndClose_Click"/>
     </Grid>
 </Window>

--- a/WpfApp3/LogViewer.xaml.cs
+++ b/WpfApp3/LogViewer.xaml.cs
@@ -19,17 +19,24 @@ namespace ScriptArcade
     /// </summary>
     public partial class LogViewerWindow : Window
     {
-        public string logText { get; private set; }
+        public static readonly DependencyProperty LogTextProperty =
+            DependencyProperty.Register(nameof(LogText), typeof(string), typeof(LogViewerWindow), new PropertyMetadata(string.Empty));
+
+        public string LogText
+        {
+            get => (string)GetValue(LogTextProperty);
+            set => SetValue(LogTextProperty, value);
+        }
 
         public LogViewerWindow(string theseLogs)
         {
             InitializeComponent();
-            ViewerPopout.Text = theseLogs;
+            LogText = theseLogs;
+            DataContext = this;
         }
 
         private void SaveAndClose_Click(object sender, RoutedEventArgs e)
         {
-            logText = ViewerPopout.Text;
             DialogResult = true;
             Close();
         }

--- a/WpfApp3/MainWindow.xaml
+++ b/WpfApp3/MainWindow.xaml
@@ -113,6 +113,7 @@
 
                         <ListBox x:Name="lb_savedQueries" HorizontalAlignment="Left" Height="147" Margin="698,36,0,0" VerticalAlignment="Top" Width="168" FontSize="10" SelectionChanged="lb_savedQueries_SelectionChanged"/>
                         <Button x:Name="btnLoadQuery" Content="Load" HorizontalAlignment="Left" Height="24" Margin="818,186,0,0" VerticalAlignment="Top" Width="48" FontSize="13" Click="btnLoadQuery_Click"/>
+                        <Button x:Name="btnPopoutWmi" Content="Pop-Out Results" HorizontalAlignment="Left" Height="24" Margin="698,186,0,0" VerticalAlignment="Top" Width="110" FontSize="13" Click="OpenWmiResultsPopout_Click"/>
                         <DataGrid x:Name="dgWmiResults" HorizontalAlignment="Center" Height="500" Margin="0,307,0,0" VerticalAlignment="Top" Width="973" FontSize="13" Panel.ZIndex="6" Foreground="#FFFFEE33">
                             <DataGrid.Background>
                                 <ImageBrush ImageSource="e60fdf1f-3c21-4333-a1cb-6c65d3865f9d.png"/>

--- a/WpfApp3/MainWindow.xaml.cs
+++ b/WpfApp3/MainWindow.xaml.cs
@@ -313,15 +313,36 @@ namespace ScriptArcade
         }
         private void OpenLogsPopou(object sender, RoutedEventArgs e)
         {
-            var theseLogs = new System.Windows.Documents.TextRange(editorLogs.Document.ContentStart, editorLogs.Document.ContentEnd).Text;
+            if (dg_logs.ItemsSource != null && dg_logs.Visibility == Visibility.Visible)
+            {
+                var gridPopup = new DataGridViewerWindow(dg_logs.ItemsSource);
+                gridPopup.Owner = this;
+                gridPopup.Show();
+                return;
+            }
 
+            var theseLogs = new System.Windows.Documents.TextRange(editorLogs.Document.ContentStart, editorLogs.Document.ContentEnd).Text;
             var popupViewer = new LogViewerWindow(theseLogs);
             bool? result = popupViewer.ShowDialog();
 
             if (result == true)
             {
                 editorLogs.Document.Blocks.Clear();
-                editorLogs.AppendText(popupViewer.logText);
+                editorLogs.AppendText(popupViewer.LogText);
+            }
+        }
+
+        private void OpenWmiResultsPopout_Click(object sender, RoutedEventArgs e)
+        {
+            if (dgWmiResults.ItemsSource != null)
+            {
+                var gridPopup = new DataGridViewerWindow(dgWmiResults.ItemsSource);
+                gridPopup.Owner = this;
+                gridPopup.Show();
+            }
+            else
+            {
+                MessageBox.Show("No results to display.");
             }
         }
         private void lb_jobs_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -331,12 +352,16 @@ namespace ScriptArcade
                 if (IsStructuredData(job.Log, out var tableData))
                 {
                     dg_logs.ItemsSource = tableData.DefaultView;
+                    dg_logs.Visibility = Visibility.Visible;
+                    editorLogs.Visibility = Visibility.Collapsed;
                 }
                 else
                 {
                     dg_logs.IsEnabled = false;
+                    dg_logs.Visibility = Visibility.Collapsed;
                     // Fallback to plain text display
                     editorLogs.IsEnabled = true;
+                    editorLogs.Visibility = Visibility.Visible;
                     editorLogs.Document.Blocks.Clear();
                     editorLogs.AppendText(job.Log);
                 }

--- a/WpfApp3/Window1.xaml
+++ b/WpfApp3/Window1.xaml
@@ -5,12 +5,13 @@
         Title="Script Editor" Height="450" Width="800">
     <Grid>
         <avalonEdit:TextEditor x:Name="editorPopout"
+                               Text="{Binding ScriptText, UpdateSourceTrigger=PropertyChanged}"
                                FontFamily="Consolas"
                                FontSize="14"
                                ShowLineNumbers="True"
                                HorizontalScrollBarVisibility="Auto"
-                               VerticalScrollBarVisibility="Auto" TabIndex="2147483642" WordWrap="True"
-                               />
+                               VerticalScrollBarVisibility="Auto"
+                               TabIndex="2147483642" WordWrap="True" />
         <Button Content="Save and Close" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="10"
                 Click="SaveAndClose_Click"/>
     </Grid>

--- a/WpfApp3/Window1.xaml.cs
+++ b/WpfApp3/Window1.xaml.cs
@@ -19,18 +19,26 @@ namespace ScriptArcade
     /// </summary>
     public partial class ScriptEditorWindow : Window
     {
-        public string ScriptText { get; private set; }
+        public static readonly DependencyProperty ScriptTextProperty =
+            DependencyProperty.Register(nameof(ScriptText), typeof(string), typeof(ScriptEditorWindow), new PropertyMetadata(string.Empty));
+
+        public string ScriptText
+        {
+            get => (string)GetValue(ScriptTextProperty);
+            set => SetValue(ScriptTextProperty, value);
+        }
 
         public ScriptEditorWindow(string currentScript)
         {
             InitializeComponent();
-            editorPopout.Text = currentScript;
+            ScriptText = currentScript;
+            DataContext = this;
         }
 
         private void SaveAndClose_Click(object sender, RoutedEventArgs e)
         {
-            ScriptText = editorPopout.Text;
-            this.Close();
+            DialogResult = true;
+            Close();
         }
     }
 

--- a/WpfApp3/WpfApp3.csproj
+++ b/WpfApp3/WpfApp3.csproj
@@ -115,6 +115,9 @@
     <Compile Include="AdminTools.cs" />
     <Compile Include="RemoteJob.cs" />
     <Compile Include="Settings.cs" />
+    <Compile Include="DataGridViewerWindow.xaml.cs">
+      <DependentUpon>DataGridViewerWindow.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Window1.xaml.cs">
       <DependentUpon>Window1.xaml</DependentUpon>
     </Compile>
@@ -141,6 +144,10 @@
     <Page Include="LogViewer.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="DataGridViewerWindow.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
     </Page>
     <Page Include="MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>


### PR DESCRIPTION
## Summary
- implement a `DataGridViewerWindow` for viewing grids in a pop‑out
- bind `LogViewerWindow` and `ScriptEditorWindow` controls directly to data
- detect whether logs are tabular and open the appropriate pop‑out
- allow WMI results to be shown in a separate popup

## Testing
- `dotnet build WpfApp3/WpfApp3.csproj` *(fails: reference assemblies for .NET Framework 4.7.2 not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e435f28c483269a86a63300dfb50c